### PR TITLE
Fix compiler errors and disable type checking on latest sdk

### DIFF
--- a/monkey.jungle
+++ b/monkey.jungle
@@ -1,1 +1,2 @@
 project.manifest = manifest.xml
+project.typecheck = 0

--- a/source/HuwaiiApp.mc
+++ b/source/HuwaiiApp.mc
@@ -18,19 +18,19 @@ var gLocationLng = null;
 var centerX;
 var centerY;
 
-hidden function degreesToRadians(degrees) {
+function degreesToRadians(degrees) {
 	return degrees * Math.PI / 180;
 }  
 
-hidden function radiansToDegrees(radians) {
+function radiansToDegrees(radians) {
 	return radians * 180 / Math.PI;
 }  
 
-hidden function convertCoorX(radians, radius) {
+function convertCoorX(radians, radius) {
 	return centerX + radius*Math.cos(radians);
 }
 
-hidden function convertCoorY(radians, radius) {
+function convertCoorY(radians, radius) {
 	return centerY + radius*Math.sin(radians);
 }
 
@@ -227,7 +227,7 @@ class HuwaiiApp extends Application.AppBase {
 				var day_of_weak = date.day_of_week;
 				return Lang.format("$1$ $2$",[days[day_of_weak], date.day.format("%d")]);
 			} else {
-				var date = Date.info(now, Time.FORMAT_LONG);
+				date = Date.info(now, Time.FORMAT_LONG);
 				var day_of_weak = date.day_of_week;
 				return Lang.format("$1$ $2$",[day_of_weak.toUpper(), date.day.format("%d")]);
 			}
@@ -257,7 +257,7 @@ class HuwaiiApp extends Application.AppBase {
 				day = date.day;
 				month = months[date.month];
 			} else {
-				var date = Date.info(now, Time.FORMAT_MEDIUM);
+				date = Date.info(now, Time.FORMAT_MEDIUM);
 				day = date.day;
 				month = months[date.month];
 			}

--- a/source/datafield/DataFactory.mc
+++ b/source/datafield/DataFactory.mc
@@ -789,7 +789,7 @@ class GroupNotiField extends BaseDataField {
 	
 	function cur_label(value) {
 		var settings = Sys.getDeviceSettings();
-		var value = settings.alarmCount;
+		value = settings.alarmCount;
 		var alarm_str = Lang.format("A$1$",[value.format("%d")]);
 		value = settings.notificationCount;
 		var noti_str = Lang.format("N$1$",[value.format("%d")]);
@@ -866,7 +866,6 @@ class SunField extends BaseDataField {
 	
 	function cur_label(value) {
 		if (gLocationLat != null) {
-			var value = "";
 			var nextSunEvent = 0;
 			var isSunriseNext = false;
 			var now = Date.info(Time.now(), Time.FORMAT_SHORT);
@@ -1097,7 +1096,6 @@ class TemparatureField extends BaseDataField {
 	
 	function cur_label(value) {
 		var need_minimal = App.getApp().getProperty("minimal_data");
-		var value = 0;
 		var settings = Sys.getDeviceSettings();
 		if ((Toybox has :SensorHistory) && (Toybox.SensorHistory has :getTemperatureHistory)) {
 			var sample = SensorHistory.getTemperatureHistory(null).next();
@@ -1145,7 +1143,6 @@ class AltitudeField extends BaseDataField {
 	
 	function cur_label(value) {
 		var need_minimal = App.getApp().getProperty("minimal_data");
-		var value = 0;
 		// #67 Try to retrieve altitude from current activity, before falling back on elevation history.
 		// Note that Activity::Info.altitude is supported by CIQ 1.x, but elevation history only on select CIQ 2.x
 		// devices.
@@ -1207,7 +1204,7 @@ class AlarmField extends BaseDataField {
 	
 	function cur_label(value) {
 		var settings = Sys.getDeviceSettings();
-		var value = settings.alarmCount;
+		value = settings.alarmCount;
 		return Lang.format("ALAR $1$",[value.format("%d")]);
 	}
 }
@@ -1228,7 +1225,7 @@ class NotifyField extends BaseDataField {
 	
 	function cur_label(value) {
 		var settings = Sys.getDeviceSettings();
-		var value = settings.notificationCount;
+		value = settings.notificationCount;
 		return Lang.format("NOTIF $1$",[value.format("%d")]);
 	}
 }
@@ -1351,8 +1348,7 @@ class DistanceField extends BaseDataField {
 	}
 	
 	function max_label(value) {
-		var value = value/1000.0;
-		value = value/100.0; // convert cm to km
+		value = value/(100.0 * 1000.0); // convert cm to km
     	var valKp = App.getApp().toKValue(value);
     	return Lang.format("$1$K",[valKp]);
 	}


### PR DESCRIPTION
Allows project to compile & run on latest Garmin Monkey C SDK
- remove module hidden, remove var re-declarations
- Disable type checking

Note: Type checking is disabled, which causes compiler to hide/ignore some logical errors that are detectable by the new type checking linter.